### PR TITLE
Add 'Paste Link' Menu

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -34,16 +34,38 @@ function shouldInsertAfter(block: ListItemCache | SectionCache) {
 }
 
 export default class MyPlugin extends Plugin {
+
+  copiedFile: TFile | null = null;
+  copiedSubPath: string | null = null;
+  copiedIsHeading: boolean = false;
+
   async onload() {
     this.registerEvent(
       this.app.workspace.on("editor-menu", (menu, editor, view) => {
+
+        if (!((this.copiedFile === null)||(this.copiedSubPath===null))) {
+          menu.addItem((item) => {
+            item
+              .setTitle(this.copiedIsHeading?"Paste link to heading":"Paste link to block")
+              .setIcon("links-going-out")
+              .onClick(() => this.handlePaste(view.file, editor, false));
+          });
+
+          menu.addItem((item) => {
+            item
+              .setTitle(this.copiedIsHeading?"Paste heading embed":"Paste block embed")
+              .setIcon("links-going-out")
+              .onClick(() => this.handlePaste(view.file, editor, true));
+          });
+        }
+
         const block = this.getBlock(editor, view.file);
 
         if (!block) return;
 
         const isHeading = !!(block as any).heading;
 
-        const onClick = (isEmbed: boolean) => {
+        const onCopy = (isEmbed: boolean) => {
           if (isHeading) {
             this.handleHeading(view.file, block as HeadingCache, isEmbed);
           } else {
@@ -60,17 +82,33 @@ export default class MyPlugin extends Plugin {
           item
             .setTitle(isHeading ? "Copy link to heading" : "Copy link to block")
             .setIcon("links-coming-in")
-            .onClick(() => onClick(false));
+            .onClick(() => onCopy(false));
         });
 
         menu.addItem((item) => {
           item
             .setTitle(isHeading ? "Copy heading embed" : "Copy block embed")
             .setIcon("links-coming-in")
-            .onClick(() => onClick(true));
+            .onClick(() => onCopy(true));
         });
       })
     );
+
+    this.addCommand({
+      id: "paste-link-to-block",
+      name: "Paste link to last copied block or heading",
+      editorCheckCallback: (isChecking, editor, view) => {
+        return this.handlePasteCommand(isChecking, editor, view, false);
+      },
+    });
+
+    this.addCommand({
+      id: "paste-embed-to-block",
+      name: "Copy embed to last copied block or heading",
+      editorCheckCallback: (isChecking, editor, view) => {
+        return this.handlePasteCommand(isChecking, editor, view, true);
+      },
+    });
 
     this.addCommand({
       id: "copy-link-to-block",
@@ -87,6 +125,19 @@ export default class MyPlugin extends Plugin {
         return this.handleCommand(isChecking, editor, view, true);
       },
     });
+    
+
+  }
+
+  handlePasteCommand(isChecking: boolean, editor: Editor, view: MarkdownView, isEmbed: boolean) {
+    const shouldAbort = (this.copiedFile === null) || (this.copiedSubPath === null);
+    if (isChecking) {
+      return shouldAbort;
+    }
+    if (shouldAbort){
+      return
+    }
+    this.handlePaste(view.file, editor, isEmbed);
   }
 
   handleCommand(
@@ -147,11 +198,16 @@ export default class MyPlugin extends Plugin {
   }
 
   handleHeading(file: TFile, block: HeadingCache, isEmbed: boolean) {
+
+    this.copiedFile = file;
+    this.copiedSubPath = "#" + sanitizeHeading(block.heading);
+    this.copiedIsHeading = true;
+
     navigator.clipboard.writeText(
       `${isEmbed ? "!" : ""}${this.app.fileManager.generateMarkdownLink(
-        file,
+        this.copiedFile,
         "",
-        "#" + sanitizeHeading(block.heading)
+        this.copiedSubPath
       )}`
     );
   }
@@ -163,14 +219,18 @@ export default class MyPlugin extends Plugin {
     isEmbed: boolean
   ) {
     const blockId = block.id;
+    this.copiedFile = file;
+    this.copiedIsHeading = false;
 
     // Copy existing block id
     if (blockId) {
+      this.copiedSubPath = "#^" + blockId;
+
       return navigator.clipboard.writeText(
         `${isEmbed ? "!" : ""}${this.app.fileManager.generateMarkdownLink(
-          file,
+          this.copiedFile,
           "",
-          "#^" + blockId
+          this.copiedSubPath
         )}`
       );
     }
@@ -183,14 +243,29 @@ export default class MyPlugin extends Plugin {
     };
 
     const id = generateId();
+    this.copiedSubPath = "#^" + id;
     const spacer = shouldInsertAfter(block) ? "\n\n" : " ";
 
     editor.replaceRange(`${spacer}^${id}`, end);
     navigator.clipboard.writeText(
       `${isEmbed ? "!" : ""}${this.app.fileManager.generateMarkdownLink(
-        file,
+        this.copiedFile,
         "",
-        "#^" + id
+        this.copiedSubPath
+      )}`
+    );
+  }
+
+  handlePaste(file: TFile, editor: Editor, isEmbed: boolean) {
+    if ((this.copiedFile === null) || (this.copiedSubPath === null)) {
+      return;
+    }
+
+    return editor.replaceSelection(
+      `${isEmbed ? "!" : ""}${this.app.fileManager.generateMarkdownLink(
+        this.copiedFile,
+        file.path,
+        this.copiedSubPath
       )}`
     );
   }


### PR DESCRIPTION
I hacked together two menu entries and commands for pasting links and embedded links. This has the advantage that the target file is known and relative paths can be calculated by obsidian.

Internally the file, subpath(heading or block) and if the link was a heading is stored so that i can be used to recalculate the link based on the currently open file to paste into.

Do you think an extra menu is the right way to go? One could also hook into the`Workspace.on('editor-paste')` handler. That would require checking the clipboard for the last copied link ( don't want to paste the link if the clipboard was modified). Maybe adding settings to switch between those behaviors would be nice.

I'm by no means a JS dev and i find the obsidian docs to be not that verbose. If you have objections to the coding style or i made some mistakes, let me know, I'll get to it.

Should fix #25 or at least be a workaround for it.